### PR TITLE
fix: if条件式内の${{ }}を削除して構文エラーを修正

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Check minimum changed lines since last review
         id: check-minimum-lines
-        if: github.event_name == 'pull_request' && steps.check-skip-message.outputs.skip != 'true' && ${{ inputs.minimum_changed_lines }} != 0
+        if: github.event_name == 'pull_request' && steps.check-skip-message.outputs.skip != 'true' && inputs.minimum_changed_lines != 0
         continue-on-error: true
         run: |
           echo "Checking skip conditions..."


### PR DESCRIPTION
## Summary
- `claude-review.yml` の `if` 条件式の途中で `${{ inputs.minimum_changed_lines }}` を使っていたことで、GitHub Actions のバリデーションエラー（"Conditional expression contains literal text outside replacement tokens"）が発生していたのを修正
- `if:` の値は式コンテキストとして評価されるため、`inputs.minimum_changed_lines` を直接参照する形に変更

## Test plan
- [ ] 呼び出し側ワークフロー（claude-code-review.yml）からの起動時に構文エラーが解消されることを確認
- [ ] `minimum_changed_lines` が 0 / 非0 のそれぞれで `check-minimum-lines` ステップの実行可否が想定通りに切り替わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)