### PR TITLE
[review] code-reviewのデフォルトモデルをsonnetに変更

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -8,10 +8,10 @@ on:
         required: true
         type: string
       model:
-        description: 'Claude model to use (empty for default Sonnet 4)'
+        description: 'Claude model to use (default: sonnet; empty string falls back to the action default)'
         required: false
         type: string
-        default: ''
+        default: 'sonnet'
       minimum_changed_lines:
         description: 'Minimum number of changed lines since last review to trigger review (0 means always run)'
         required: false

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ secrets:
 
 **パラメータ:**
 - `guideline_files`: コードレビューのガイドラインファイルのパス一覧（改行区切り）
-- `model`: 使用するClaudeモデル（オプション、デフォルトはSonnet 4）
+- `model`: 使用するClaudeモデル（オプション、デフォルトは `sonnet`。空文字を明示指定するとアクション側のデフォルトになる）
 - `minimum_changed_lines`: 前回レビューからの最小変更行数（デフォルト: 0、0の場合は常に実行）
 - `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
 


### PR DESCRIPTION
何も指定しないとaction側デフォルトでopusが使われるようになったため、
modelのデフォルトを明示的にsonnetに設定する。空文字を明示指定した場合は
従来どおりaction側デフォルトにフォールバックする挙動を維持。