### PR TITLE
chore: runs-onのデフォルトrunnerを更新

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,24 +4,24 @@ on:
   workflow_call:
     inputs:
       guideline_files:
-        description: 'Paths to guideline files for code review (newline-separated)'
+        description: "Paths to guideline files for code review (newline-separated)"
         required: true
         type: string
       model:
-        description: 'Claude model to use (default: sonnet; empty string falls back to the action default)'
+        description: "Claude model to use (default: sonnet; empty string falls back to the action default)"
         required: false
         type: string
-        default: 'sonnet'
+        default: "sonnet"
       minimum_changed_lines:
-        description: 'Minimum number of changed lines since last review to trigger review (0 means always run)'
+        description: "Minimum number of changed lines since last review to trigger review (0 means always run)"
         required: false
         type: number
         default: 0
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-24.04-arm"
     secrets:
       claude_oauth_token:
         required: false
@@ -123,7 +123,7 @@ jobs:
           token: ${{ github.token }}
           usernames: claude[bot]
           noReply: "true"
-          onlyNotMinimized: 'true'
+          onlyNotMinimized: "true"
           includeOverallReviewComments: "true"
 
       - name: Get existing Claude comments

--- a/.github/workflows/copytuner_deploy.yml
+++ b/.github/workflows/copytuner_deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   copytuner_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/gem_changelog.yml
+++ b/.github/workflows/gem_changelog.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -21,7 +21,7 @@ jobs:
   gem_changelog:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/new_gems.yml
+++ b/.github/workflows/new_gems.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -17,7 +17,7 @@ jobs:
   new_gems:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/new_npm.yml
+++ b/.github/workflows/new_npm.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-slim"
 
 jobs:
   pre_job:

--- a/.github/workflows/npm_changelog.yml
+++ b/.github/workflows/npm_changelog.yml
@@ -9,10 +9,10 @@ on:
         required: false
         type: string
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-slim"
 
 jobs:
   pre_job:

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -4,20 +4,20 @@ on:
   workflow_call:
     inputs:
       source_branch:
-        description: 'デプロイ元のブランチ名'
+        description: "デプロイ元のブランチ名"
         required: false
-        default: 'release-candidate'
+        default: "release-candidate"
         type: string
       target_branch:
-        description: 'デプロイ先のブランチ名'
+        description: "デプロイ先のブランチ名"
         required: false
-        default: 'staging'
+        default: "staging"
         type: string
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-slim"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ package.jsonの変更を検出し、新しく追加されたnpmパッケージ�
 ```yaml
 uses: SonicGarden/workflows/.github/workflows/new_npm.yml@main
 with:
-  runs_on: "linux-arm64-default" # オプション、デフォルトは "linux-arm64-default"
+  runs_on: "ubuntu-slim" # オプション、デフォルトは "ubuntu-slim"
 ```
 
 **パラメータ:**
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-slim`）
 
 ### 5. npm_changelog
 npm/yarnのロックファイルの変更を検出し、更新されたパッケージのchangelogをPRコメントに投稿するワークフローです。
@@ -68,12 +68,12 @@ npm/yarnのロックファイルの変更を検出し、更新されたパッケ
 uses: SonicGarden/workflows/.github/workflows/npm_changelog.yml@main
 with:
   lockPath: "yarn.lock" # オプション、デフォルトは "yarn.lock"
-  runs_on: "linux-arm64-default" # オプション、デフォルトは "linux-arm64-default"
+  runs_on: "ubuntu-slim" # オプション、デフォルトは "ubuntu-slim"
 ```
 
 **パラメータ:**
 - `lockPath`: ロックファイルのパス（デフォルト: `yarn.lock`）
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-slim`）
 
 ### 6. staging_deploy
 指定されたブランチから staging ブランチへの自動デプロイPRを作成・管理するワークフローです。
@@ -84,13 +84,13 @@ uses: SonicGarden/workflows/.github/workflows/staging_deploy.yml@main
 with:
   source_branch: "release-candidate" # オプション、デフォルトは "release-candidate"
   target_branch: "staging" # オプション、デフォルトは "staging"
-  runs_on: "linux-arm64-default" # オプション、デフォルトは "linux-arm64-default"
+  runs_on: "ubuntu-slim" # オプション、デフォルトは "ubuntu-slim"
 ```
 
 **パラメータ:**
 - `source_branch`: デプロイ元のブランチ名（デフォルト: `release-candidate`）
 - `target_branch`: デプロイ先のブランチ名（デフォルト: `staging`）
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-slim`）
 
 **機能:**
 - 既存のPRがあるかをチェック
@@ -135,7 +135,7 @@ secrets:
 - `guideline_files`: コードレビューのガイドラインファイルのパス一覧（改行区切り）
 - `model`: 使用するClaudeモデル（オプション、デフォルトは `sonnet`。空文字を明示指定するとアクション側のデフォルトになる）
 - `minimum_changed_lines`: 前回レビューからの最小変更行数（デフォルト: 0、0の場合は常に実行）
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-24.04-arm`）
 
 **必要なシークレット:**
 - `claude_oauth_token`: Claude OAuth トークン（推奨）


### PR DESCRIPTION
## 変更内容

- `ubuntu-latest` → `ubuntu-slim` に変更（copytuner_deploy, gem_changelog, new_gems）
- `linux-arm64-default` → `ubuntu-slim` に変更（new_npm, npm_changelog, staging_deploy）
- `linux-arm64-default` → `ubuntu-24.04-arm` に変更（claude-review）
- YAML の文字列クォートをシングルクォートからダブルクォートに統一