### PR TITLE
feat: staging_deployにenable_auto_mergeオプションを追加

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -4,24 +4,24 @@ on:
   workflow_call:
     inputs:
       guideline_files:
-        description: 'Paths to guideline files for code review (newline-separated)'
+        description: "Paths to guideline files for code review (newline-separated)"
         required: true
         type: string
       model:
-        description: 'Claude model to use (default: sonnet; empty string falls back to the action default)'
+        description: "Claude model to use (default: sonnet; empty string falls back to the action default)"
         required: false
         type: string
-        default: 'sonnet'
+        default: "sonnet"
       minimum_changed_lines:
-        description: 'Minimum number of changed lines since last review to trigger review (0 means always run)'
+        description: "Minimum number of changed lines since last review to trigger review (0 means always run)"
         required: false
         type: number
         default: 0
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-24.04-arm"
     secrets:
       claude_oauth_token:
         required: false
@@ -123,7 +123,7 @@ jobs:
           token: ${{ github.token }}
           usernames: claude[bot]
           noReply: "true"
-          onlyNotMinimized: 'true'
+          onlyNotMinimized: "true"
           includeOverallReviewComments: "true"
 
       - name: Get existing Claude comments

--- a/.github/workflows/copytuner_deploy.yml
+++ b/.github/workflows/copytuner_deploy.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   copytuner_deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
 
     steps:

--- a/.github/workflows/gem_changelog.yml
+++ b/.github/workflows/gem_changelog.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   pre_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -21,7 +21,7 @@ jobs:
   gem_changelog:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/new_gems.yml
+++ b/.github/workflows/new_gems.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   pre_job:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
@@ -17,7 +17,7 @@ jobs:
   new_gems:
     needs: pre_job
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/new_npm.yml
+++ b/.github/workflows/new_npm.yml
@@ -4,10 +4,10 @@ on:
   workflow_call:
     inputs:
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-slim"
 
 jobs:
   pre_job:

--- a/.github/workflows/npm_changelog.yml
+++ b/.github/workflows/npm_changelog.yml
@@ -9,10 +9,10 @@ on:
         required: false
         type: string
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-slim"
 
 jobs:
   pre_job:

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -4,20 +4,20 @@ on:
   workflow_call:
     inputs:
       source_branch:
-        description: 'デプロイ元のブランチ名'
+        description: "デプロイ元のブランチ名"
         required: false
-        default: 'release-candidate'
+        default: "release-candidate"
         type: string
       target_branch:
-        description: 'デプロイ先のブランチ名'
+        description: "デプロイ先のブランチ名"
         required: false
-        default: 'staging'
+        default: "staging"
         type: string
       runs_on:
-        description: 'GitHub Actions runner to use'
+        description: "GitHub Actions runner to use"
         required: false
         type: string
-        default: 'linux-arm64-default'
+        default: "ubuntu-slim"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: "ubuntu-slim"
+      enable_auto_merge:
+        description: "CI通過後にPRを自動マージするか"
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +75,7 @@ jobs:
           ### 変更内容
           ${{ github.event.head_commit.message }}
 
-          CIが全て通過したら自動的にマージされます。
+          CIが全て通過したら、設定に応じて自動的にマージされます。
 
           ---
           _このPRは自動生成されました_"
@@ -99,7 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for new PR
-        if: steps.create-pr.outputs.pr_number != ''
+        if: inputs.enable_auto_merge && steps.create-pr.outputs.pr_number != ''
         run: |
           # NOTE: 新しく作成されたPRに対して自動マージを設定
           gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --merge
@@ -108,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for existing PR
-        if: steps.check-pr.outputs.existing_pr != ''
+        if: inputs.enable_auto_merge && steps.check-pr.outputs.existing_pr != ''
         run: |
           # NOTE: 既存のPRに対して自動マージを設定（まだ設定されていない場合）
           gh pr merge ${{ steps.check-pr.outputs.existing_pr }} --auto --merge
@@ -127,7 +132,7 @@ jobs:
           ### 最新の変更内容
           ${{ github.event.head_commit.message }}
 
-          CIが全て通過したら自動的にマージされます。
+          CIが全て通過したら、設定に応じて自動的にマージされます。
 
           ---
           _このPRは自動生成されました（最終更新: $(date '+%Y-%m-%d %H:%M:%S'))_"

--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ package.jsonの変更を検出し、新しく追加されたnpmパッケージ�
 ```yaml
 uses: SonicGarden/workflows/.github/workflows/new_npm.yml@main
 with:
-  runs_on: "linux-arm64-default" # オプション、デフォルトは "linux-arm64-default"
+  runs_on: "ubuntu-24.04-arm" # オプション、デフォルトは "ubuntu-24.04-arm"
 ```
 
 **パラメータ:**
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-24.04-arm`）
 
 ### 5. npm_changelog
 npm/yarnのロックファイルの変更を検出し、更新されたパッケージのchangelogをPRコメントに投稿するワークフローです。
@@ -68,12 +68,12 @@ npm/yarnのロックファイルの変更を検出し、更新されたパッケ
 uses: SonicGarden/workflows/.github/workflows/npm_changelog.yml@main
 with:
   lockPath: "yarn.lock" # オプション、デフォルトは "yarn.lock"
-  runs_on: "linux-arm64-default" # オプション、デフォルトは "linux-arm64-default"
+  runs_on: "ubuntu-24.04-arm" # オプション、デフォルトは "ubuntu-24.04-arm"
 ```
 
 **パラメータ:**
 - `lockPath`: ロックファイルのパス（デフォルト: `yarn.lock`）
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-24.04-arm`）
 
 ### 6. staging_deploy
 指定されたブランチから staging ブランチへの自動デプロイPRを作成・管理するワークフローです。
@@ -84,13 +84,13 @@ uses: SonicGarden/workflows/.github/workflows/staging_deploy.yml@main
 with:
   source_branch: "release-candidate" # オプション、デフォルトは "release-candidate"
   target_branch: "staging" # オプション、デフォルトは "staging"
-  runs_on: "linux-arm64-default" # オプション、デフォルトは "linux-arm64-default"
+  runs_on: "ubuntu-24.04-arm" # オプション、デフォルトは "ubuntu-24.04-arm"
 ```
 
 **パラメータ:**
 - `source_branch`: デプロイ元のブランチ名（デフォルト: `release-candidate`）
 - `target_branch`: デプロイ先のブランチ名（デフォルト: `staging`）
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-24.04-arm`）
 
 **機能:**
 - 既存のPRがあるかをチェック
@@ -135,7 +135,7 @@ secrets:
 - `guideline_files`: コードレビューのガイドラインファイルのパス一覧（改行区切り）
 - `model`: 使用するClaudeモデル（オプション、デフォルトは `sonnet`。空文字を明示指定するとアクション側のデフォルトになる）
 - `minimum_changed_lines`: 前回レビューからの最小変更行数（デフォルト: 0、0の場合は常に実行）
-- `runs_on`: GitHub Actions runner の指定（デフォルト: `linux-arm64-default`）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-24.04-arm`）
 
 **必要なシークレット:**
 - `claude_oauth_token`: Claude OAuth トークン（推奨）

--- a/README.md
+++ b/README.md
@@ -85,20 +85,24 @@ with:
   source_branch: "release-candidate" # オプション、デフォルトは "release-candidate"
   target_branch: "staging" # オプション、デフォルトは "staging"
   runs_on: "ubuntu-24.04-arm" # オプション、デフォルトは "ubuntu-24.04-arm"
+  enable_auto_merge: true # オプション、デフォルトは true
 ```
 
 **パラメータ:**
 - `source_branch`: デプロイ元のブランチ名（デフォルト: `release-candidate`）
 - `target_branch`: デプロイ先のブランチ名（デフォルト: `staging`）
 - `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-24.04-arm`）
+- `enable_auto_merge`: CI通過後にPRを自動マージするか（デフォルト: `true`）。`false` にするとPRの作成・更新のみ行い、自動マージは設定しない
 
 **機能:**
 - 既存のPRがあるかをチェック
 - 新しいPRの作成または既存PRの更新
-- 自動マージの設定
+- 自動マージの設定（`enable_auto_merge: true` の場合のみ）
 - `[skip deploy]` がコミットメッセージに含まれている場合はスキップ
 
 **GitHub上での設定（CIが通ってから自動マージするため）:**
+
+> **Note:** 以下の設定は `enable_auto_merge: true`（デフォルト）で自動マージを利用する場合に必要です。`false` の場合は不要です。
 
 このワークフローでPRが自動的にマージされるようにするには、リポジトリで以下の設定が必要です：
 


### PR DESCRIPTION
## 概要

`staging_deploy` 再利用可能ワークフローに `enable_auto_merge` オプションを追加し、CI通過後の自動マージを呼び出し側で制御できるようにしました。

## 変更内容

- `enable_auto_merge` 入力（boolean、デフォルト `true`）を追加。`false` にするとPRの作成・更新のみ行い、自動マージは設定しない
- auto-merge の2ステップ（新規PR用・既存PR用）の `if:` 条件に `inputs.enable_auto_merge` を追加
- PR本文の文言を auto-merge ON/OFF どちらでも通用する「設定に応じて自動的にマージされます」に変更
- README に `enable_auto_merge` の説明を追記