### PR TITLE
feat: staging_deployにenable_auto_mergeオプションを追加

### DIFF
--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -18,6 +18,11 @@ on:
         required: false
         type: string
         default: "ubuntu-slim"
+      enable_auto_merge:
+        description: "CI通過後にPRを自動マージするか"
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -70,7 +75,7 @@ jobs:
           ### 変更内容
           ${{ github.event.head_commit.message }}
 
-          CIが全て通過したら自動的にマージされます。
+          CIが全て通過したら、設定に応じて自動的にマージされます。
 
           ---
           _このPRは自動生成されました_"
@@ -99,7 +104,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for new PR
-        if: steps.create-pr.outputs.pr_number != ''
+        if: inputs.enable_auto_merge && steps.create-pr.outputs.pr_number != ''
         run: |
           # NOTE: 新しく作成されたPRに対して自動マージを設定
           gh pr merge ${{ steps.create-pr.outputs.pr_number }} --auto --merge
@@ -108,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enable auto-merge for existing PR
-        if: steps.check-pr.outputs.existing_pr != ''
+        if: inputs.enable_auto_merge && steps.check-pr.outputs.existing_pr != ''
         run: |
           # NOTE: 既存のPRに対して自動マージを設定（まだ設定されていない場合）
           gh pr merge ${{ steps.check-pr.outputs.existing_pr }} --auto --merge
@@ -127,7 +132,7 @@ jobs:
           ### 最新の変更内容
           ${{ github.event.head_commit.message }}
 
-          CIが全て通過したら自動的にマージされます。
+          CIが全て通過したら、設定に応じて自動的にマージされます。
 
           ---
           _このPRは自動生成されました（最終更新: $(date '+%Y-%m-%d %H:%M:%S'))_"

--- a/README.md
+++ b/README.md
@@ -85,20 +85,24 @@ with:
   source_branch: "release-candidate" # オプション、デフォルトは "release-candidate"
   target_branch: "staging" # オプション、デフォルトは "staging"
   runs_on: "ubuntu-slim" # オプション、デフォルトは "ubuntu-slim"
+  enable_auto_merge: true # オプション、デフォルトは true
 ```
 
 **パラメータ:**
 - `source_branch`: デプロイ元のブランチ名（デフォルト: `release-candidate`）
 - `target_branch`: デプロイ先のブランチ名（デフォルト: `staging`）
 - `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-slim`）
+- `enable_auto_merge`: CI通過後にPRを自動マージするか（デフォルト: `true`）。`false` にするとPRの作成・更新のみ行い、自動マージは設定しない
 
 **機能:**
 - 既存のPRがあるかをチェック
 - 新しいPRの作成または既存PRの更新
-- 自動マージの設定
+- 自動マージの設定（`enable_auto_merge: true` の場合のみ）
 - `[skip deploy]` がコミットメッセージに含まれている場合はスキップ
 
 **GitHub上での設定（CIが通ってから自動マージするため）:**
+
+> **Note:** 以下の設定は `enable_auto_merge: true`（デフォルト）で自動マージを利用する場合に必要です。`false` の場合は不要です。
 
 このワークフローでPRが自動的にマージされるようにするには、リポジトリで以下の設定が必要です：
 


### PR DESCRIPTION
## 概要
`staging_deploy` ワークフローに `enable_auto_merge` オプションを追加しました。

## 変更内容
- `enable_auto_merge` 入力を追加（boolean、デフォルト `true`）
- `false` のときは PR の作成・更新のみ行い、自動マージは設定しないように分岐を追加
- README に `enable_auto_merge` の説明と、自動マージ利用時のみ GitHub 設定が必要である旨の Note を追記