### PR TITLE
feat: claude-review-pluginワークフローを追加

### DIFF
--- a/.github/workflows/claude-review-plugin.yml
+++ b/.github/workflows/claude-review-plugin.yml
@@ -1,0 +1,160 @@
+name: Claude Code Review (Plugin)
+
+# claude-review.yml (GitHub MCP直接呼び出し方式) とは別に、aki77/claude-plugins の
+# code-review プラグイン(Skill方式)を --plugin-dir で読み込んで実行する再利用可能ワークフロー。
+#
+# NOTE: workflow_call では pull_request/issue_comment トリガーを定義できないため、
+#       トリガーと concurrency は呼び出し側で定義する(README の使用例を参照)。
+
+on:
+  workflow_call:
+    inputs:
+      plugin_ref:
+        description: "aki77/claude-plugins の ref (ブランチ/タグ/SHA)"
+        required: false
+        type: string
+        default: "main"
+      additional_claude_args:
+        description: "claude_args の末尾に追記する追加引数 (モデル変更、allowedTools追加など)"
+        required: false
+        type: string
+        default: ""
+      model:
+        description: "Claude model to use (default: sonnet; empty string falls back to the action default)"
+        required: false
+        type: string
+        default: "sonnet"
+      runs_on:
+        description: "GitHub Actions runner to use"
+        required: false
+        type: string
+        default: "ubuntu-24.04-arm"
+      github_token:
+        description: "claude-code-action に渡す GitHub トークン"
+        required: false
+        type: string
+        default: ""
+    secrets:
+      claude_oauth_token:
+        required: false
+        description: Claude OAuth token for code review
+      anthropic_api_key:
+        required: false
+        description: Anthropic API key for code review
+
+jobs:
+  claude-review:
+    if: |
+      (github.event.issue.pull_request && contains(github.event.comment.body, '/review')) ||
+      (
+        github.event_name == 'pull_request' &&
+        github.actor != 'dependabot[bot]' &&
+        !github.event.pull_request.draft &&
+        !contains(github.event.pull_request.title, '[skip review]') &&
+        !contains(join(github.event.pull_request.labels.*.name, ','), 'reviewed-by-claude')
+      )
+    runs-on: ${{ inputs.runs_on }}
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      checks: read
+
+    steps:
+      - name: Resolve PR info (issue_comment only)
+        id: pr
+        if: github.event_name == 'issue_comment'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr view "$PR_NUMBER" \
+            --repo "$REPO" \
+            --json headRefOid,baseRefName \
+            --jq '"sha=" + .headRefOid, "base_ref=" + .baseRefName' \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          token: ${{ github.token }}
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || steps.pr.outputs.sha }}
+
+      # NOTE: checkoutはPR head SHAを指定して取得するため、baseブランチのローカルrefは
+      # PR作成時点のコミットしか指さない。base側にforce pushや通常のpushで新しいコミットが
+      # 積まれていると、code-reviewスキルのdiff取得がそのbase refとの間でmerge-baseを
+      # 計算できずレビュー0件で終わる。そこでbaseブランチを明示的にfetchして最新化しておく。
+      # refspecを明示してrefs/remotes/origin/<base>を永続化する。refspec無しfetchはFETCH_HEADに
+      # 取得するだけでローカルrefを作らず、後続のRun Claude Code Reviewが行うPR head対策のgit操作で
+      # FETCH_HEAD由来の到達性が失われ、merge-baseが計算できずレビュー0件で終了する
+      - name: Fetch base branch
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || steps.pr.outputs.base_ref }}
+        run: git fetch origin "$BASE_REF:refs/remotes/origin/$BASE_REF"
+
+      - name: Ensure reviewed-by-claude label exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh label create "reviewed-by-claude" \
+            --repo "${{ github.repository }}" \
+            --color "5319e7" \
+            --description "Claude Code による自動レビュー済み" \
+            --force
+
+      - uses: aki77/delete-pr-comments-action@v3
+        with:
+          token: ${{ github.token }}
+          usernames: claude[bot]
+          noReply: "true"
+          onlyNotMinimized: "true"
+          includeOverallReviewComments: "true"
+
+      - name: Clone claude-plugins
+        env:
+          PLUGIN_REF: ${{ inputs.plugin_ref }}
+        run: |
+          git clone --depth=1 --branch "$PLUGIN_REF" \
+            https://github.com/aki77/claude-plugins.git /tmp/claude-plugins
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.claude_oauth_token }}
+          anthropic_api_key: ${{ secrets.claude_oauth_token != '' && '' || secrets.anthropic_api_key }}
+          github_token: ${{ inputs.github_token }}
+          display_report: true
+          # NOTE: 通常実行ではログを汚さず、デバッグ時のみ全出力を表示する。
+          #       runner.debug は「Re-run with debug logging」やシークレット
+          #       ACTIONS_STEP_DEBUG=true を設定したときに '1' になる標準フラグ。
+          show_full_output: ${{ runner.debug == '1' }}
+
+          # NOTE: issue_comment / pull_request 双方のイベントで正しいPRを参照させるため、リポジトリとPR番号を明示する
+          prompt: |
+            /code-review:pr-review --comment
+            Repository: ${{ github.repository }}
+            PR Number: ${{ github.event.pull_request.number || github.event.issue.number }}
+            PR Head SHA: ${{ github.event.pull_request.head.sha || steps.pr.outputs.sha }}
+          use_sticky_comment: true
+          # NOTE: marketplace経由のインストールではなく、plugin_refで固定したclone済みディレクトリを
+          #       --plugin-dirで読み込む。これにより使用するプラグインのバージョンを呼び出し側で
+          #       明示的にpin/管理でき、上流main更新によるレビュー挙動の予期しない変化を避けられる。
+          claude_args: |
+            ${{ inputs.model != '' && format('--model {0}', inputs.model) || '' }}
+            --allowedTools "Skill,Write,Read,Grep,Glob,Bash(gh:*),Bash(git rev-parse:*),Bash(git diff:*),Bash(git show:*),Bash(git log:*),Bash(git fetch:*),Bash(node:*),Bash(jq:*),Bash(bundle show:*),WebSearch,WebFetch"
+            --plugin-dir /tmp/claude-plugins/plugins/code-review
+            --add-dir /tmp
+            ${{ inputs.additional_claude_args }}
+
+      - name: Add reviewed-by-claude label
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_NUMBER=${{ github.event.pull_request.number || github.event.issue.number }}
+          gh pr edit "$PR_NUMBER" --repo "${{ github.repository }}" --add-label "reviewed-by-claude"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Reusable GitHub Actions workflows
 ## 利用可能なワークフロー
 
 ### 1. copytuner_deploy
-Copytune翻訳管理ツールへの翻訳情報をデプロイするワークフローです。
+
+<details>
+<summary>Copytune翻訳管理ツールへの翻訳情報をデプロイするワークフローです。</summary>
 
 **使用方法:**
 ```yaml
@@ -28,8 +30,12 @@ secrets:
 **必要なシークレット:**
 - `apiKey`: CopytunerのAPIキー
 
+</details>
+
 ### 2. gem_changelog
-Gemfile.lockの変更を検出し、更新されたgemのchangelogをPRコメントに投稿するワークフローです。
+
+<details>
+<summary>Gemfile.lockの変更を検出し、更新されたgemのchangelogをPRコメントに投稿するワークフローです。</summary>
 
 **使用方法:**
 ```yaml
@@ -41,16 +47,24 @@ secrets:
 **オプションのシークレット:**
 - `rubygemsToken`: RubyGems.orgのAPIトークン（スコープ: `Index rubygems`）
 
+</details>
+
 ### 3. new_gems
-Gemfileの変更を検出し、新しく追加されたgemをPRコメントに投稿するワークフローです。
+
+<details>
+<summary>Gemfileの変更を検出し、新しく追加されたgemをPRコメントに投稿するワークフローです。</summary>
 
 **使用方法:**
 ```yaml
 uses: SonicGarden/workflows/.github/workflows/new_gems.yml@main
 ```
 
+</details>
+
 ### 4. new_npm
-package.jsonの変更を検出し、新しく追加されたnpmパッケージをPRコメントに投稿するワークフローです。
+
+<details>
+<summary>package.jsonの変更を検出し、新しく追加されたnpmパッケージをPRコメントに投稿するワークフローです。</summary>
 
 **使用方法:**
 ```yaml
@@ -62,8 +76,12 @@ with:
 **パラメータ:**
 - `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-slim`）
 
+</details>
+
 ### 5. npm_changelog
-npm/yarnのロックファイルの変更を検出し、更新されたパッケージのchangelogをPRコメントに投稿するワークフローです。
+
+<details>
+<summary>npm/yarnのロックファイルの変更を検出し、更新されたパッケージのchangelogをPRコメントに投稿するワークフローです。</summary>
 
 **使用方法:**
 ```yaml
@@ -77,8 +95,12 @@ with:
 - `lockPath`: ロックファイルのパス（デフォルト: `yarn.lock`）
 - `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-slim`）
 
+</details>
+
 ### 6. staging_deploy
-指定されたブランチから staging ブランチへの自動デプロイPRを作成・管理するワークフローです。
+
+<details>
+<summary>指定されたブランチから staging ブランチへの自動デプロイPRを作成・管理するワークフローです。</summary>
 
 **使用方法:**
 ```yaml
@@ -120,8 +142,12 @@ with:
 
 これらの設定により、CIが全て通過した後に自動的にPRがマージされます。
 
+</details>
+
 ### 7. claude-review
-Claude Code を使用してPRの自動コードレビューを実行するワークフローです。
+
+<details>
+<summary>Claude Code を使用してPRの自動コードレビューを実行するワークフローです。</summary>
 
 **使用方法:**
 ```yaml
@@ -154,8 +180,12 @@ secrets:
 - 既存のClaude botコメントを自動削除して重複を防止
 - `[skip review]` がコミットメッセージに含まれている場合はレビューをスキップ
 
+</details>
+
 ### 8. heroku_deploy_notify
-Heroku-GitHub 自動デプロイ対象ブランチへの push を契機に、Heroku Platform API をポーリングしてリリースの完了/失敗を検知し、そのマージコミットに紐づく PR にデプロイ結果をコメントするワークフローです。デプロイ本体には介入しない外形監視です。
+
+<details>
+<summary>Heroku-GitHub 自動デプロイ対象ブランチへの push を契機に、Heroku Platform API をポーリングしてリリースの完了/失敗を検知し、そのマージコミットに紐づく PR にデプロイ結果をコメントするワークフローです。デプロイ本体には介入しない外形監視です。</summary>
 
 **使用方法:**
 
@@ -211,8 +241,12 @@ jobs:
 - マージコミットに紐づく PR にデプロイ結果（成功/失敗/タイムアウト）をコメント
 - PR コメントは `push` イベント時のみ（手動実行などでは誤爆防止でスキップ）
 
+</details>
+
 ### 9. claude-dependabot-review
-Dependabot の依存更新 PR について、CI（テスト）が緑でも見逃しがちな「ランタイム挙動の変化・deprecation」を CHANGELOG ベースで Claude に評価させ、PR へ要約コメントを 1 本残すワークフローです。検出/分類は Dependabot に、「壊れたか」は CI に任せ、本WFは「緑でも危ういもの」を拾う役に徹します。言語・フレームワークには依存しません。
+
+<details>
+<summary>Dependabot の依存更新 PR について、CI（テスト）が緑でも見逃しがちな「ランタイム挙動の変化・deprecation」を CHANGELOG ベースで Claude に評価させ、PR へ要約コメントを 1 本残すワークフローです。検出/分類は Dependabot に、「壊れたか」は CI に任せ、本WFは「緑でも危ういもの」を拾う役に徹します。言語・フレームワークには依存しません。</summary>
 
 **使用方法:**
 
@@ -263,20 +297,4 @@ jobs:
 - PR へのコメントは 1 本に集約（既存の Claude コメントを自動削除して重複を防止）
 - `head_sha` に紐づく open PR が見つからない場合はスキップ
 
-## 使用例
-
-他のリポジトリからこれらのワークフローを使用する場合は、`.github/workflows/` ディレクトリに以下のようなファイルを作成してください：
-
-```yaml
-name: Example Workflow
-on:
-  pull_request:
-    paths:
-      - 'Gemfile.lock'
-
-jobs:
-  gem-changelog:
-    uses: SonicGarden/workflows/.github/workflows/gem_changelog.yml@main
-    secrets:
-      rubygemsToken: ${{ secrets.RUBYGEMS_TOKEN }}
-```
+</details>

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Reusable GitHub Actions workflows
 - [claude-review](#7-claude-review) - Claude Codeによる自動コードレビュー
 - [heroku_deploy_notify](#8-heroku_deploy_notify) - Herokuデプロイ完了/失敗をPRに通知
 - [claude-dependabot-review](#9-claude-dependabot-review) - Dependabot更新PRをCI緑でも危うい観点でClaudeレビュー
+- [claude-review-plugin](#10-claude-review-plugin) - claude-pluginsのSkill方式によるClaude Code自動コードレビュー
 
 ## 利用可能なワークフロー
 
@@ -296,5 +297,66 @@ jobs:
 - ベースブランチ（更新適用前の現状コード）のみを checkout し、信頼コンテキストに untrusted な PR HEAD を置かない
 - PR へのコメントは 1 本に集約（既存の Claude コメントを自動削除して重複を防止）
 - `head_sha` に紐づく open PR が見つからない場合はスキップ
+
+</details>
+
+### 10. claude-review-plugin
+
+<details>
+<summary>Claude Code の `code-review` プラグイン（`/code-review:pr-review` Skill）を使ってPRの自動コードレビューを実行するワークフローです。GitHub MCPツールを直接呼び出す `claude-review` とは異なり、Skill内でBash/git等を使ってdiffを取得する方式です。`/review` PRコメントによる再実行、`reviewed-by-claude` ラベルでの二重レビュー防止を備えています。</summary>
+
+**使用方法:**
+
+再利用可能ワークフローでは `pull_request` / `issue_comment` トリガーを定義できないため、呼び出し側でトリガーと `concurrency` を定義します。
+
+```yaml
+name: Claude Code Review
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+  issue_comment:
+    types: [created]
+
+concurrency:
+  # NOTE: PR更新時のレビューと/reviewコメントは同じgroupで同時実行を防ぐ (例: workflow--pr-123)
+  # NOTE: 単なるコメントでもアクション自体は発動してしまうので、/review以外のコメントは個別groupで無関係なキャンセルを防ぐ (例: workflow--comment-456)
+  group: |
+    ${{
+      github.event_name == 'pull_request' && format('{0}--pr-{1}', github.workflow, github.event.pull_request.number) ||
+      contains(github.event.comment.body, '/review') && format('{0}--pr-{1}', github.workflow, github.event.issue.number) ||
+      format('{0}--comment-{1}', github.workflow, github.event.comment.id)
+    }}
+  cancel-in-progress: true
+
+jobs:
+  claude-review:
+    uses: SonicGarden/workflows/.github/workflows/claude-review-plugin.yml@main
+    secrets:
+      # 以下どちらかが必須
+      claude_oauth_token: ${{ secrets.CLAUDE_OAUTH_TOKEN }}
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+**パラメータ:**
+- `plugin_ref`: `aki77/claude-plugins` の ref（オプション、デフォルト: `main`。ブランチ/タグ/SHAでバージョンをロック可能）
+- `additional_claude_args`: `claude_args` の末尾に追記する追加引数（オプション、デフォルト: `""`。モデル変更やallowedTools追加など）
+- `model`: 使用するClaudeモデル（オプション、デフォルトは `sonnet`。空文字を明示指定するとアクション側のデフォルトになる）
+- `runs_on`: GitHub Actions runner の指定（デフォルト: `ubuntu-24.04-arm`）
+
+**必要なシークレット:**
+- `claude_oauth_token`: Claude OAuth トークン（推奨）
+- `anthropic_api_key`: Anthropic API キー（claude_oauth_tokenがない場合のフォールバック）
+
+**機能:**
+- `/code-review:pr-review` Skillによる自動レビュー（インラインコメント）
+- PRコメントで `/review` と投稿すると再レビューを実行
+- `reviewed-by-claude` ラベルを自動作成・付与し、二重レビューを防止
+- 既存のClaude botコメントを自動削除して重複を防止
+- fork PR対策としてベースブランチを明示的にfetch
+- ドラフトPR、`[skip review]` を含むタイトル、Dependabot起点のPRは自動的にスキップ（Dependabot更新PRは `claude-dependabot-review` を利用）
+
+**前提:**
+- 呼び出し側リポジトリに `pull_request` / `issue_comment` トリガーと `concurrency` を定義すること
+- リポジトリ固有の除外条件（特定ブランチ間のPRを除外するなど）が必要な場合は、呼び出し側のジョブに `if` 条件を追加すること
 
 </details>


### PR DESCRIPTION
## Summary
- aki77/claude-plugins の code-review プラグイン（`/code-review:pr-review` Skill）を `--plugin-dir` で読み込んで実行する再利用可能ワークフロー `claude-review-plugin.yml` を追加
- GitHub MCPツールを直接呼び出す既存の `claude-review` とは別方式として、Skill内でBash/git等を使ってdiffを取得する方式を並行提供
- `/review` コメントによる再実行、`reviewed-by-claude` ラベルによる二重レビュー防止、fork PR対策のベースブランチfetchなどを実装
- README.mdの各ワークフロー説明を `<details>` で折りたたみ表示にし、新ワークフロー（10. claude-review-plugin）の使用方法・パラメータ・前提条件を追記

## Test plan
- [ ] `claude-review-plugin.yml` を呼び出す側ワークフローを別リポジトリに設置し、PR作成時に自動レビューが動作することを確認
- [ ] PRコメントで `/review` を投稿し、再レビューが実行されることを確認
- [ ] `reviewed-by-claude` ラベル付与後、再度のPR更新でラベルが正しく扱われることを確認